### PR TITLE
Support parameters for default route

### DIFF
--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -121,8 +121,8 @@ class RouteTree {
 
     var components = usePath.split("/");
 
-    if (path == Navigator.defaultRouteName) {
-      components = ["/"];
+    if (RegExp(r"(\/$|\/\?.*)").hasMatch(path)) {
+      components = [path];
     }
 
     var nodeMatches = <RouteTreeNode, RouteTreeNodeMatch>{};


### PR DESCRIPTION
Currently, the default route ("/") followed by any query parameters will fail to match, resulting in a not found.