### PR TITLE
Support parameters for default route

### DIFF
--- a/lib/src/tree.dart
+++ b/lib/src/tree.dart
@@ -121,8 +121,8 @@ class RouteTree {
 
     var components = usePath.split("/");
 
-    if (path == Navigator.defaultRouteName) {
-      components = ["/"];
+    if (RegExp(r"(\/$|\/\?.*)").hasMatch(path)) {
+      components = [path];
     }
 
     var nodeMatches = <RouteTreeNode, RouteTreeNodeMatch>{};


### PR DESCRIPTION
Package is redirecting to notFound handler when url is https://google.com/?fbclid=123

This changes fixes the issue.